### PR TITLE
Persist room config and fix moderator JWT features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -972,15 +972,15 @@ function AppProvider({ children }: { children: React.ReactNode }) {
           const defaultProxy = WebhookProxy.getInstance(
             activeConfig.webhooksProxy.url,
             activeConfig.webhooksProxy.sharedSecret,
-            'test-room',
+            currentConference,
             activeConfig.tenant
           )
 
           // Connect directly to remote proxy server
           defaultProxy.connect()
 
-          newConferences.set('test-room', {
-            name: 'test-room',
+          newConferences.set(currentConference, {
+            name: currentConference,
             proxy: defaultProxy
           })
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -807,7 +807,8 @@ function AppProvider({ children }: { children: React.ReactNode }) {
   console.log('AppProvider: Component rendering')
   const [config, setConfig] = useState<Config | null>(null)
   const [conferences, setConferences] = useState<Map<string, ConferenceState>>(new Map())
-  const [currentConference, setCurrentConference] = useState<string>('test-room')
+  const [currentConference, setCurrentConference] = useState<string>(
+    () => localStorage.getItem('current-conference') || 'test-room')
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -829,6 +830,7 @@ function AppProvider({ children }: { children: React.ReactNode }) {
   const [moderator, setModerator] = useState<boolean>(() => localStorage.getItem('participants-moderator') === 'true')
   const [visitor, setVisitor] = useState<boolean>(() => localStorage.getItem('participants-visitor') === 'true')
 
+  useEffect(() => { localStorage.setItem('current-conference', currentConference) }, [currentConference])
   useEffect(() => { localStorage.setItem('participants-prejoin', prejoinScreen) }, [prejoinScreen])
   useEffect(() => { localStorage.setItem('participants-p2p', p2pSetting) }, [p2pSetting])
   useEffect(() => { localStorage.setItem('participants-audio', audioSetting) }, [audioSetting])

--- a/src/WebhookProxy.ts
+++ b/src/WebhookProxy.ts
@@ -265,9 +265,22 @@ class WebhookProxy {
     set defaultMeetingSettings(value: IMeetingSettings) {
         console.log('Default meeting settings set to:', value);
         this._defaultMeetingSettings = value;
+        try {
+            localStorage.setItem(`meeting-settings-${this.conferenceName}`, JSON.stringify(value));
+        } catch {
+            // ignore
+        }
     }
 
     get defaultMeetingSettings(): IMeetingSettings | undefined {
+        if (!this._defaultMeetingSettings) {
+            try {
+                const saved = localStorage.getItem(`meeting-settings-${this.conferenceName}`);
+                if (saved) this._defaultMeetingSettings = JSON.parse(saved);
+            } catch {
+                // ignore
+            }
+        }
         return this._defaultMeetingSettings;
     }
 


### PR DESCRIPTION
- Persist prejoin/audio/video/p2p participant panel options to localStorage
- Persist room name across page reloads
- Persist meeting settings (visitors flags etc.) per room across page reloads
- Fix: omit empty `features` from JWT payload when moderator is set but no permissions toggled, so JaaS applies default moderator behavior